### PR TITLE
fix: find all required libraries

### DIFF
--- a/chimerax.nix
+++ b/chimerax.nix
@@ -5,7 +5,11 @@ let
   # source of the latter disappears much faster.
   version = "rc";
 
-  src = ./chimerax-rc.deb;
+  src = fetchurl {
+    url = "https://www.cgl.ucsf.edu/chimerax/cgi-bin/secure/chimerax-get.py?ident=OHeQer2fSLp7%2BfxtoHxc5%2Flkr0FSQ9j%2B3ht23gv5ifI%3D&file=current%2Fubuntu-22.04%2Fchimerax-rc.deb&choice=Notified";
+    sha256 = "4EDZHiXJGv3KMQCF9EyC73Zwl28fTS29y6IEroD+c4k=";
+  };
+  
   libnsl = stdenv.mkDerivation rec {
     pname = "libnsl";
     version = "1.3.0";

--- a/chimerax.nix
+++ b/chimerax.nix
@@ -1,86 +1,101 @@
-{ pkgs, stdenv, fetchurl, autoPatchelfHook }:
+{ pkgs, stdenv, dpkg, glibc, gcc-unwrapped, autoPatchelfHook }:
+let
 
-let 
+  # Please keep the version x.y.0.z and do not update to x.y.76.z because the
+  # source of the latter disappears much faster.
+  version = "rc";
+
+  src = ./chimerax-rc.deb;
+  libnsl = stdenv.mkDerivation rec {
+    pname = "libnsl";
+    version = "1.3.0";
+    src = pkgs.fetchFromGitHub {
+      owner = "thkukuk";
+      repo = pname;
+      rev = "v${version}";
+      sha256 = "1dayj5i4bh65gn7zkciacnwv2a0ghm6nn58d78rsi4zby4lyj5w5";
+    };
+
+    nativeBuildInputs = [ pkgs.autoreconfHook pkgs.pkg-config ];
+    buildInputs = [ pkgs.libtirpc ];
+  };
   my-python-packages = python-packages: with python-packages; [
     webencodings
-  ]; 
+  ];
   python-with-my-packages = pkgs.python39.withPackages my-python-packages;
 in
-stdenv.mkDerivation {
-  pname = "chimerax";
-  version = "1.4";
-  src = fetchurl {
-#    url =
-#      "https://www.cgl.ucsf.edu/chimerax/cgi-bin/secure/chimerax-get.py?ident=OHeQer2fSLp7%2BfxtoHxc5%2Flkr0FSQ9j90xJ03g75hA%3D%3D&file=1.4%2Flinux%2FChimeraX-1.4.tar.gz&choice=Notified";
-    url =
-      "https://www.rbvi.ucsf.edu/chimerax/cgi-bin/secure/chimerax-get.py?ident=OHeQer2fSLp7%2BfxtoHxc5%2Flkr0FSQ9j%2B0xtz0gr5gvM%3D&file=1.4%2Flinux%2FChimeraX-1.4.tar.gz&choice=Notified";
-    sha256 = "00JVND2G+46IkjApDs837C2kLxLV9IZATCDE3mNRfIc=";
-  };
+stdenv.mkDerivation rec {
+  name = "chimerax-${version}";
+
+  system = "x86_64-linux";
+
+  inherit src;
+
+  # Required for compilation
+  nativeBuildInputs = [
+    autoPatchelfHook # Automatically setup the loader, and do the magic
+    pkgs.addOpenGLRunpath
+    pkgs.cudaPackages.autoAddOpenGLRunpathHook
+    pkgs.qt6.wrapQtAppsHook
+    dpkg
+  ];
+
+  # Required at running time
   buildInputs = [
+    glibc
+    gcc-unwrapped
+    pkgs.linuxKernel.packages.linux_5_19.nvidia_x11
     pkgs.libffi
-          pkgs.qt6.wrapQtAppsHook
-          pkgs.glib
-          pkgs.gdk-pixbuf
-          pkgs.cairo
-          pkgs.pango
-          pkgs.udev
-          pkgs.alsa-lib
-          pkgs.gtk3
-          pkgs.webkitgtk
-          pkgs.pkg-config
-          pkgs.xorg.libX11
-          pkgs.xorg.libXcursor
-          pkgs.xorg.libXrandr
-          pkgs.gcc-unwrapped
-          pkgs.ffmpeg 
-          pkgs.qt4
-          pkgs.qt6.qt3d
-          pkgs.qt6.qtquick3d
-          pkgs.qt6.qtwebview
-          pkgs.opencl-info
-          pkgs.ncurses
-          pkgs.opencl-clang
-          pkgs.opencl-headers
-          pkgs.rocm-opencl-runtime
-          pkgs.opencl-clhpp
-          pkgs.conda
-          pkgs.vial
-          pkgs.mysql80
-          python-with-my-packages
-        ];
-        propagatedBuildInputs = [
-          pkgs.libffi
-           pkgs.qt6.wrapQtAppsHook
-          pkgs.glib
-          pkgs.gdk-pixbuf
-          pkgs.cairo
-          pkgs.pango
-          pkgs.udev
-          pkgs.alsa-lib
-          pkgs.gtk3
-          pkgs.webkitgtk
-          pkgs.pkg-config
-          pkgs.xorg.libX11
-          pkgs.xorg.libXcursor
-          pkgs.xorg.libXrandr
-          pkgs.gcc-unwrapped
-          pkgs.ffmpeg 
-          pkgs.qt4
-          pkgs.qt6.qt3d
-          pkgs.qt6.qtquick3d
-          pkgs.qt6.qtwebview
-          pkgs.opencl-info
-          pkgs.ncurses
-          pkgs.opencl-clang
-          pkgs.opencl-headers
-          pkgs.rocm-opencl-runtime
-          pkgs.opencl-clhpp
-          pkgs.conda
-          pkgs.vial
-          pkgs.mysql80
-          python-with-my-packages       
-        ];
-  nativeBuildInputs = [ autoPatchelfHook ];
-  installPhase = ./chimerax-install.sh;
-  system = builtins.currentSystem;
+    pkgs.qt6.wrapQtAppsHook
+    pkgs.glib
+    pkgs.gdk-pixbuf
+    pkgs.cairo
+    pkgs.pango
+    pkgs.udev
+    pkgs.alsa-lib
+    pkgs.gtk3
+    pkgs.webkitgtk
+    pkgs.pkg-config
+    pkgs.xorg.libX11
+    pkgs.xorg.libXcursor
+    pkgs.xorg.libXrandr
+    pkgs.gcc-unwrapped
+    pkgs.ffmpeg
+    pkgs.qt4
+    pkgs.qt6.qt3d
+    pkgs.qt6.qtquick3d
+    pkgs.qt6.qtwebview
+    pkgs.opencl-info
+    pkgs.ncurses
+    pkgs.libtirpc
+    libnsl
+    pkgs.opencl-clang
+    pkgs.opencl-headers
+    pkgs.rocm-opencl-runtime
+    pkgs.opencl-clhpp
+    pkgs.conda
+    pkgs.vial
+    pkgs.mysql80
+    pkgs.cudaPackages.cudatoolkit
+    pkgs.openssl_3
+    python-with-my-packages
+  ];
+  propagatedBuildInputs = buildInputs;
+  unpackPhase = "true";
+
+  # Extract and copy executable in $out/bin
+  installPhase = ''
+    mkdir -p $out
+    dpkg -x $src $out
+    cp -av $out/usr/* $out
+    rm -rf $out/usr
+  '';
+
+  # meta = with stdenv.lib; {
+  #   description = "ChimeraX";
+  #   homepage = https://www.cgl.ucsf.edu/chimerax/;
+  #   license = licenses.mit;
+  #   maintainers = with stdenv.lib.maintainers; [ ];
+  #   platforms = [ "x86_64-linux" ];
+  # };
 }

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,122 @@
+{ pkgs, stdenv, dpkg, glibc, gcc-unwrapped, autoPatchelfHook }:
+let
+
+  # Please keep the version x.y.0.z and do not update to x.y.76.z because the
+  # source of the latter disappears much faster.
+  version = "rc";
+
+  src = ./chimerax-rc.deb;
+  libnsl = stdenv.mkDerivation rec {
+    pname = "libnsl";
+    version = "1.3.0";
+    src = pkgs.fetchFromGitHub {
+      owner = "thkukuk";
+      repo = pname;
+      rev = "v${version}";
+      sha256 = "1dayj5i4bh65gn7zkciacnwv2a0ghm6nn58d78rsi4zby4lyj5w5";
+    };
+
+    nativeBuildInputs = [ pkgs.autoreconfHook pkgs.pkg-config ];
+    buildInputs = [ pkgs.libtirpc ];
+  };
+  my-python-packages = python-packages: with python-packages; [
+    webencodings
+    xkbcommon
+   # pyqt6
+  ];
+  python-with-my-packages = pkgs.python39.withPackages my-python-packages;
+in
+stdenv.mkDerivation rec {
+  name = "chimerax-${version}";
+
+  system = "x86_64-linux";
+
+  inherit src;
+
+  # Required for compilation
+  nativeBuildInputs = [
+    autoPatchelfHook # Automatically setup the loader, and do the magic
+    #pkgs.addOpenGLRunpath
+    #pkgs.cudaPackages.autoAddOpenGLRunpathHook
+    pkgs.qt6.wrapQtAppsHook
+    dpkg
+  ];
+
+  # Required at running time
+  buildInputs = [
+    glibc
+    #gcc-unwrapped
+    pkgs.linuxKernel.packages.linux_5_19.nvidia_x11
+    pkgs.libffi
+    pkgs.qt6.wrapQtAppsHook
+    pkgs.glib
+    pkgs.gdk-pixbuf
+    pkgs.cairo
+    pkgs.pango
+    pkgs.udev
+    pkgs.libGLU
+    pkgs.alsa-lib
+    pkgs.gtk3
+    pkgs.webkitgtk
+    pkgs.pkg-config
+    #pkgs.xorg.libX11
+    # pkgs.xorg.libXcursor
+    # pkgs.xorg.libXrandr
+    pkgs.xorg.xkbevd
+    pkgs.kbd
+    pkgs.xkeyboard_config
+    pkgs.libxkbcommon
+    pkgs.gcc-unwrapped
+    pkgs.ffmpeg
+    pkgs.qt6.qt3d
+    pkgs.qt6.qtquick3d
+    pkgs.qt6.qtwebview
+    pkgs.opencl-info
+    pkgs.ncurses
+    pkgs.libtirpc
+    libnsl
+    pkgs.opencl-clang
+    pkgs.opencl-headers
+    pkgs.rocm-opencl-runtime
+    pkgs.opencl-clhpp
+    pkgs.conda
+    pkgs.vial
+    pkgs.mysql80
+    pkgs.cudaPackages.cudatoolkit
+    pkgs.openssl_3
+    python-with-my-packages
+  ];
+  propagatedBuildInputs = buildInputs;
+  unpackPhase = "true";
+  dontAutoPatchelf = true;
+  dontStrip = true;
+
+  # Extract and copy executable in $out/bin
+  installPhase = ''
+    mkdir -p $out
+    dpkg -x $src $out
+    cp -av $out/usr/lib/ucsf-chimerax/* $out
+    rm -rf $out/usr
+    #rm -rf $out/lib/python3.9
+    rm -rf $out/bin/amber20
+    rm $out/bin/python3.9
+    rm $out/lib/libpython*
+  '';
+
+  postFixup = ''
+    autoPatchelf $out/bin
+    autoPatchelf $out/lib
+    dpkg -x $src $out
+    #mkdir $out/lib/python3.9
+    #cp -av $out/usr/lib/ucsf-chimerax/lib/python3.9/site-packages $out/lib/site-packages
+    rm -rf $out/usr
+  '';
+
+  # meta = with stdenv.lib; {
+  #   description = "ChimeraX";
+  #   homepage = https://www.cgl.ucsf.edu/chimerax/;
+  #   license = licenses.mit;
+  #   maintainers = with stdenv.lib.maintainers; [ ];
+  #   platforms = [ "x86_64-linux" ];
+  # };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -2,15 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1666424192,
-        "narHash": "sha256-rb/a7Kg9s31jqkvdOQHFrUc5ig5kB+O2ZKB8mjU2kW8=",
+        "lastModified": 1663368971,
+        "narHash": "sha256-vYspG3uX/e1j9tt8erYF8esWDJRz9nuBHesc/ZUWgAU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4f8287f3d597c73b0d706cfad028c2d51821f64d",
+        "rev": "d529e6962d22d13e28439c67adbf1ef7381f7143",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
+        "rev": "d529e6962d22d13e28439c67adbf1ef7381f7143",
         "type": "indirect"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -1,10 +1,19 @@
 {
   description = "ChimeraX is an application for visualizing and analyzing molecule structures such as proteins, RNA, DNA, lipids as well as gene sequences, electron microscopy maps, X-ray maps, 3D light microscopy and 3D medical imaging scans. It is the successor of the UCSF Chimera program.";
+  # 22.05
+  #inputs = { nixpkgs.url = "nixpkgs/72783a2d0dbbf030bff1537873dd5b85b3fb332f"; };
+  # qt 6.3
+  inputs = { nixpkgs.url = "nixpkgs/d529e6962d22d13e28439c67adbf1ef7381f7143"; };
   outputs = { self, nixpkgs }:
     let
       pkgs = import nixpkgs { system = "x86_64-linux"; };
-      chimerax = pkgs.callPackage ./chimerax.nix {};
+      chimerax = pkgs.callPackage ./default.nix {};
     in {
+      packages = {
+        x86_64-linux = {
+        default = chimerax;
+      };
+      };
       devShells = {
         x86_64-linux = {
         default = pkgs.mkShell {


### PR DESCRIPTION
By using the deb file instead of the 1.4 release, we can get all of the libraries to resolve. However, they include a bunch of files in python site-packages with whitespace in their name, which nix is unhappy with.

Things that still need to be done:

1. Fix the deb download link (something like - https://www.cgl.ucsf.edu/chimerax/cgi-bin/secure/chimerax-get.py?ident=OHeQer2WTKFn%2F%2BVvtnxc5P1pr0FSQ9j%2B0RJy0g35gPg%3D&file=current%2Fubuntu-22.04%2Fchimerax-rc.deb&choice=Notified )
2. Figure out how to fix the pathing issues
3. Provide cuda libs in a driver independent manner